### PR TITLE
Fix activation button

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
       "editor/title": [
         {
           "action": "cssStackingContexts.toggleDecorations",
-          "when": "resource.language == 'css' || resource.language == 'scss'"
+          "when": "(resource.language == 'css') || (resource.language == 'scss')"
         }
       ]
     }


### PR DESCRIPTION
This was only activating the button (making it colorful) on scss files but not css files for me. I believe the reason is that it was not handling this expression correctly (testing locally, this fixed the button at least). See the first limitation bullet here: https://docs.sourcegraph.com/extensions/authoring/context_key_expressions#limitations 